### PR TITLE
fix: getStackTrace() 구문 제거

### DIFF
--- a/src/main/java/com/supercoding/shoppingmallbackend/common/Error/GlobalExceptionHandler.java
+++ b/src/main/java/com/supercoding/shoppingmallbackend/common/Error/GlobalExceptionHandler.java
@@ -67,8 +67,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public CommonResponse<?> handleException(Exception e) {
-        e.printStackTrace();
         log.error(e.getMessage(), 500);
-        return CommonResponse.fail(new CustomException(CommonErrorCode.INTERNAL_SERVER_ERROR));
+        return CommonResponse.fail(CommonErrorCode.INTERNAL_SERVER_ERROR.getErrorCode());
     }
 }


### PR DESCRIPTION
new CustomeException()을 제거 함으로 해당로직에서 사용자에게 값을 반환함